### PR TITLE
Update AppsFlyer SDK to 6.17.8

### DIFF
--- a/AdobeAEPSample/Podfile
+++ b/AdobeAEPSample/Podfile
@@ -8,7 +8,7 @@ target 'Adobe AEP Sample' do
   pod 'AEPSignal'
   pod 'AEPMobileServices'
   pod 'AEPAnalytics' 
-  pod 'AppsFlyerAdobeAEPExtension','6.17.7'
+  pod 'AppsFlyerAdobeAEPExtension','6.17.8'
   pod 'AEPCore'
 
 end

--- a/AppsFlyerAdobeAEPExtension.podspec
+++ b/AppsFlyerAdobeAEPExtension.podspec
@@ -5,8 +5,8 @@
 #  To learn more about Podspec attributes see https://guides.cocoapods.org/syntax/podspec.html
 #  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
 #
-version_appsflyerLib = '6.17.7'
-version_plugin = '6.17.7'
+version_appsflyerLib = '6.17.8'
+version_plugin = '6.17.8'
    
 Pod::Spec.new do |s|
   s.name             = 'AppsFlyerAdobeAEPExtension'

--- a/AppsFlyerAdobeExtension/Sources/AppsFlyerConstants.swift
+++ b/AppsFlyerAdobeExtension/Sources/AppsFlyerConstants.swift
@@ -9,7 +9,7 @@ import Foundation
 enum AppsFlyerConstants {
   static let EXTENSION_NAME = "com.appsflyer.adobeextension" 
   static let FRIENDLY_NAME = "AppsFlyerAdobeExtension"
-  static let EXTENSION_VERSION = "6.17.7"
+  static let EXTENSION_VERSION = "6.17.8"
   static let EVENT_GETTER_RESPONSE_DATA_KEY = "getterdata"
   static let EVENT_SETTER_REQUEST_DATA_KEY = "setterdata"
   static let AF_BRIDGE_SET = "bridge is set"

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "AppsFlyerLib" , url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Static.git",  .exact("6.17.7")),
+        .package(name: "AppsFlyerLib" , url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Static.git",  .exact("6.17.8")),
         .package(url: "https://github.com/adobe/aepsdk-core-ios.git", from: "4.0.0"),
         .package(url: "https://github.com/adobe/aepsdk-edge-ios.git", from: "4.0.0")
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ### <a id="plugin-build-for"> This plugin is built for
 
-- iOS AppsFlyer SDK **6.17.7**
+- iOS AppsFlyer SDK **6.17.8**
 
 <!---
 ## <a id="breaking-changes"> 	❗❗ Breaking changes when updating to ✏️v*.*.*✏️❗❗

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,6 @@
+### 6.17.8
+* * Appsflyer SDK dependency to 6.17.8
+
 ### 6.17.7
 * * Appsflyer SDK dependency to 6.17.7
 


### PR DESCRIPTION
## Changes

- Update AppsFlyer SDK from 6.17.7 to 6.17.8

## Testing

- Built and ran example app on iPhone 17
- Verified SDK starts correctly (v6.17.8)
- Verified conversion data callback received successfully