### PR TITLE
Fix SPM Adobe AEP 5.x dependency (6.17.81)

### DIFF
--- a/AdobeAEPSample/Adobe AEP Sample/AppDelegate.swift
+++ b/AdobeAEPSample/Adobe AEP Sample/AppDelegate.swift
@@ -13,7 +13,6 @@ import AEPSignal
 import AppsFlyerAdobeAEPExtension
 import AppsFlyerLib
 import AEPAnalytics
-import AEPMobileServices
 import AppTrackingTransparency
 
 @main
@@ -32,7 +31,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     MobileCore.setLogLevel(.debug)
     MobileCore.registerExtensions([Lifecycle.self, Identity.self, Signal.self,
                                    Analytics.self,
-                                   AEPMobileServices.self, AppsFlyerAdobeExtension.self]) {
+                                   AppsFlyerAdobeExtension.self]) {
     }
       MobileCore.configureWith(appId: "REPLACE_WITH_YOUR_ADOBE_KEY")
 

--- a/AdobeAEPSample/AdobeAEPSample.xcodeproj/project.pbxproj
+++ b/AdobeAEPSample/AdobeAEPSample.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		7EB6C9FC2FC6FA28007F679F /* AppsFlyerAdobeAEPExtension in Frameworks */ = {isa = PBXBuildFile; productRef = 7EB6C9FB2FC6FA28007F679F /* AppsFlyerAdobeAEPExtension */; };
+		7EB6C9FF2FC6FE68007F679F /* AppsFlyerAdobeAEPExtension in Frameworks */ = {isa = PBXBuildFile; productRef = 7EB6C9FE2FC6FE68007F679F /* AppsFlyerAdobeAEPExtension */; };
 		C66DE3EB270F2FB700DE3AEC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66DE3EA270F2FB700DE3AEC /* AppDelegate.swift */; };
 		C66DE3ED270F2FB700DE3AEC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66DE3EC270F2FB700DE3AEC /* SceneDelegate.swift */; };
 		C66DE3EF270F2FB700DE3AEC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66DE3EE270F2FB700DE3AEC /* ViewController.swift */; };
@@ -35,6 +36,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7EB6C9FF2FC6FE68007F679F /* AppsFlyerAdobeAEPExtension in Frameworks */,
 				7EB6C9FC2FC6FA28007F679F /* AppsFlyerAdobeAEPExtension in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -418,6 +420,10 @@
 		7EB6C9FB2FC6FA28007F679F /* AppsFlyerAdobeAEPExtension */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 7EB6C9FA2FC6FA28007F679F /* XCRemoteSwiftPackageReference "appsflyer-adobe-mobile-ios-swift-extension" */;
+			productName = AppsFlyerAdobeAEPExtension;
+		};
+		7EB6C9FE2FC6FE68007F679F /* AppsFlyerAdobeAEPExtension */ = {
+			isa = XCSwiftPackageProductDependency;
 			productName = AppsFlyerAdobeAEPExtension;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/AdobeAEPSample/AdobeAEPSample.xcodeproj/project.pbxproj
+++ b/AdobeAEPSample/AdobeAEPSample.xcodeproj/project.pbxproj
@@ -7,8 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		7EB6C9FC2FC6FA28007F679F /* AppsFlyerAdobeAEPExtension in Frameworks */ = {isa = PBXBuildFile; productRef = 7EB6C9FB2FC6FA28007F679F /* AppsFlyerAdobeAEPExtension */; };
-		7EB6C9FF2FC6FE68007F679F /* AppsFlyerAdobeAEPExtension in Frameworks */ = {isa = PBXBuildFile; productRef = 7EB6C9FE2FC6FE68007F679F /* AppsFlyerAdobeAEPExtension */; };
+		2A2FDBFD28B7B88A25A67B04 /* Pods_Adobe_AEP_Sample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C261F471C942DF308541699 /* Pods_Adobe_AEP_Sample.framework */; };
+		7EB6CA022FC7164E007F679F /* AppsFlyerAdobeAEPExtension in Frameworks */ = {isa = PBXBuildFile; productRef = 7EB6CA012FC7164E007F679F /* AppsFlyerAdobeAEPExtension */; };
+		7EB6CA042FC717C9007F679F /* AEPAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 7EB6CA032FC717C9007F679F /* AEPAnalytics */; };
 		C66DE3EB270F2FB700DE3AEC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66DE3EA270F2FB700DE3AEC /* AppDelegate.swift */; };
 		C66DE3ED270F2FB700DE3AEC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66DE3EC270F2FB700DE3AEC /* SceneDelegate.swift */; };
 		C66DE3EF270F2FB700DE3AEC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66DE3EE270F2FB700DE3AEC /* ViewController.swift */; };
@@ -18,6 +19,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1C261F471C942DF308541699 /* Pods_Adobe_AEP_Sample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Adobe_AEP_Sample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		86467C4D8663393DF531BA57 /* Pods-Adobe AEP Sample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Adobe AEP Sample.release.xcconfig"; path = "Target Support Files/Pods-Adobe AEP Sample/Pods-Adobe AEP Sample.release.xcconfig"; sourceTree = "<group>"; };
 		C62EA2DA283D1334005FFEF7 /* AEPCore */ = {isa = PBXFileReference; lastKnownFileType = folder; name = AEPCore; path = "../../../../../../../../Library/Developer/Xcode/DerivedData/AdobeAEPSample-eensgbbfxqlbmnazibnemsjssjag/SourcePackages/checkouts/aepsdk-core-ios/AEPCore"; sourceTree = "<group>"; };
 		C62EA2E9283D1441005FFEF7 /* AEPCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AEPCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C65307C1271456FC0076DB91 /* Adobe AEP Sample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Adobe AEP Sample.entitlements"; sourceTree = "<group>"; };
@@ -29,6 +32,7 @@
 		C66DE3F3270F2FBC00DE3AEC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C66DE3F6270F2FBC00DE3AEC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C66DE3F8270F2FBC00DE3AEC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		EE458D6EAB8D39108AC5B51C /* Pods-Adobe AEP Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Adobe AEP Sample.debug.xcconfig"; path = "Target Support Files/Pods-Adobe AEP Sample/Pods-Adobe AEP Sample.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -36,14 +40,24 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7EB6C9FF2FC6FE68007F679F /* AppsFlyerAdobeAEPExtension in Frameworks */,
-				7EB6C9FC2FC6FA28007F679F /* AppsFlyerAdobeAEPExtension in Frameworks */,
+				7EB6CA022FC7164E007F679F /* AppsFlyerAdobeAEPExtension in Frameworks */,
+				2A2FDBFD28B7B88A25A67B04 /* Pods_Adobe_AEP_Sample.framework in Frameworks */,
+				7EB6CA042FC717C9007F679F /* AEPAnalytics in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		09D2457FBF7AE55134C691C8 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				EE458D6EAB8D39108AC5B51C /* Pods-Adobe AEP Sample.debug.xcconfig */,
+				86467C4D8663393DF531BA57 /* Pods-Adobe AEP Sample.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		C6261E67283CDA7400E0494F /* Packages */ = {
 			isa = PBXGroup;
 			children = (
@@ -58,6 +72,7 @@
 				C66DE3E9270F2FB700DE3AEC /* Adobe AEP Sample */,
 				C66DE3E8270F2FB700DE3AEC /* Products */,
 				C66DE416270F429700DE3AEC /* Frameworks */,
+				09D2457FBF7AE55134C691C8 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -89,6 +104,7 @@
 			children = (
 				C62EA2E9283D1441005FFEF7 /* AEPCore.framework */,
 				C62EA2DA283D1334005FFEF7 /* AEPCore */,
+				1C261F471C942DF308541699 /* Pods_Adobe_AEP_Sample.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -100,6 +116,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C66DE3FB270F2FBC00DE3AEC /* Build configuration list for PBXNativeTarget "Adobe AEP Sample" */;
 			buildPhases = (
+				572A5104865C5B2991B5E456 /* [CP] Check Pods Manifest.lock */,
 				C66DE3E3270F2FB700DE3AEC /* Sources */,
 				C66DE3E4270F2FB700DE3AEC /* Frameworks */,
 				C66DE3E5270F2FB700DE3AEC /* Resources */,
@@ -138,8 +155,8 @@
 			);
 			mainGroup = C66DE3DE270F2FB700DE3AEC;
 			packageReferences = (
-				7EB6C9FA2FC6FA28007F679F /* XCRemoteSwiftPackageReference "appsflyer-adobe-mobile-ios-swift-extension" */,
 				7EB6C9FD2FC6FA90007F679F /* XCRemoteSwiftPackageReference "aepsdk-analytics-ios" */,
+				7EB6CA002FC7164E007F679F /* XCRemoteSwiftPackageReference "appsflyer-adobe-mobile-ios-swift-extension" */,
 			);
 			productRefGroup = C66DE3E8270F2FB700DE3AEC /* Products */;
 			projectDirPath = "";
@@ -162,6 +179,31 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		572A5104865C5B2991B5E456 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Adobe AEP Sample-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		C66DE3E3270F2FB700DE3AEC /* Sources */ = {
@@ -314,6 +356,7 @@
 		};
 		C66DE3FC270F2FBC00DE3AEC /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = EE458D6EAB8D39108AC5B51C /* Pods-Adobe AEP Sample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -345,6 +388,7 @@
 		};
 		C66DE3FD270F2FBC00DE3AEC /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 86467C4D8663393DF531BA57 /* Pods-Adobe AEP Sample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -398,14 +442,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		7EB6C9FA2FC6FA28007F679F /* XCRemoteSwiftPackageReference "appsflyer-adobe-mobile-ios-swift-extension" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/AppsFlyerSDK/appsflyer-adobe-mobile-ios-swift-extension";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 6.17.8;
-			};
-		};
 		7EB6C9FD2FC6FA90007F679F /* XCRemoteSwiftPackageReference "aepsdk-analytics-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-analytics-ios";
@@ -414,17 +450,26 @@
 				minimumVersion = 5.0.2;
 			};
 		};
+		7EB6CA002FC7164E007F679F /* XCRemoteSwiftPackageReference "appsflyer-adobe-mobile-ios-swift-extension" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/AppsFlyerSDK/appsflyer-adobe-mobile-ios-swift-extension";
+			requirement = {
+				branch = "fix/spm-adobe-5x";
+				kind = branch;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		7EB6C9FB2FC6FA28007F679F /* AppsFlyerAdobeAEPExtension */ = {
+		7EB6CA012FC7164E007F679F /* AppsFlyerAdobeAEPExtension */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 7EB6C9FA2FC6FA28007F679F /* XCRemoteSwiftPackageReference "appsflyer-adobe-mobile-ios-swift-extension" */;
+			package = 7EB6CA002FC7164E007F679F /* XCRemoteSwiftPackageReference "appsflyer-adobe-mobile-ios-swift-extension" */;
 			productName = AppsFlyerAdobeAEPExtension;
 		};
-		7EB6C9FE2FC6FE68007F679F /* AppsFlyerAdobeAEPExtension */ = {
+		7EB6CA032FC717C9007F679F /* AEPAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = AppsFlyerAdobeAEPExtension;
+			package = 7EB6C9FD2FC6FA90007F679F /* XCRemoteSwiftPackageReference "aepsdk-analytics-ios" */;
+			productName = AEPAnalytics;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/AdobeAEPSample/AdobeAEPSample.xcodeproj/project.pbxproj
+++ b/AdobeAEPSample/AdobeAEPSample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7EB6C9FC2FC6FA28007F679F /* AppsFlyerAdobeAEPExtension in Frameworks */ = {isa = PBXBuildFile; productRef = 7EB6C9FB2FC6FA28007F679F /* AppsFlyerAdobeAEPExtension */; };
 		C66DE3EB270F2FB700DE3AEC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66DE3EA270F2FB700DE3AEC /* AppDelegate.swift */; };
 		C66DE3ED270F2FB700DE3AEC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66DE3EC270F2FB700DE3AEC /* SceneDelegate.swift */; };
 		C66DE3EF270F2FB700DE3AEC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66DE3EE270F2FB700DE3AEC /* ViewController.swift */; };
@@ -34,6 +35,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7EB6C9FC2FC6FA28007F679F /* AppsFlyerAdobeAEPExtension in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -133,6 +135,10 @@
 				Base,
 			);
 			mainGroup = C66DE3DE270F2FB700DE3AEC;
+			packageReferences = (
+				7EB6C9FA2FC6FA28007F679F /* XCRemoteSwiftPackageReference "appsflyer-adobe-mobile-ios-swift-extension" */,
+				7EB6C9FD2FC6FA90007F679F /* XCRemoteSwiftPackageReference "aepsdk-analytics-ios" */,
+			);
 			productRefGroup = C66DE3E8270F2FB700DE3AEC /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -388,6 +394,33 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		7EB6C9FA2FC6FA28007F679F /* XCRemoteSwiftPackageReference "appsflyer-adobe-mobile-ios-swift-extension" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/AppsFlyerSDK/appsflyer-adobe-mobile-ios-swift-extension";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.17.8;
+			};
+		};
+		7EB6C9FD2FC6FA90007F679F /* XCRemoteSwiftPackageReference "aepsdk-analytics-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/adobe/aepsdk-analytics-ios";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.2;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		7EB6C9FB2FC6FA28007F679F /* AppsFlyerAdobeAEPExtension */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7EB6C9FA2FC6FA28007F679F /* XCRemoteSwiftPackageReference "appsflyer-adobe-mobile-ios-swift-extension" */;
+			productName = AppsFlyerAdobeAEPExtension;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = C66DE3DF270F2FB700DE3AEC /* Project object */;
 }

--- a/AdobeAEPSample/Podfile
+++ b/AdobeAEPSample/Podfile
@@ -8,7 +8,7 @@ target 'Adobe AEP Sample' do
   pod 'AEPSignal'
   pod 'AEPMobileServices'
   pod 'AEPAnalytics' 
-  pod 'AppsFlyerAdobeAEPExtension','6.17.9'
+  pod 'AppsFlyerAdobeAEPExtension','6.17.81'
   pod 'AEPCore'
 
 end

--- a/AdobeAEPSample/Podfile
+++ b/AdobeAEPSample/Podfile
@@ -8,7 +8,7 @@ target 'Adobe AEP Sample' do
   pod 'AEPSignal'
   pod 'AEPMobileServices'
   pod 'AEPAnalytics' 
-  pod 'AppsFlyerAdobeAEPExtension','6.17.8'
+  pod 'AppsFlyerAdobeAEPExtension','6.17.9'
   pod 'AEPCore'
 
 end

--- a/AdobeAEPSample/Podfile
+++ b/AdobeAEPSample/Podfile
@@ -4,11 +4,11 @@ target 'Adobe AEP Sample' do
   use_frameworks!
 
   # Pods for Adobe AEP Sample
-  pod 'AEPLifecycle'
-  pod 'AEPSignal'
-  pod 'AEPMobileServices'
-  pod 'AEPAnalytics' 
-  pod 'AppsFlyerAdobeAEPExtension','6.17.81'
-  pod 'AEPCore'
+#  pod 'AEPLifecycle'
+#  pod 'AEPSignal'
+#  pod 'AEPMobileServices'
+#  pod 'AEPAnalytics' 
+#  pod 'AppsFlyerAdobeAEPExtension','6.17.81'
+#  pod 'AEPCore'
 
 end

--- a/AppsFlyerAdobeAEPExtension.podspec
+++ b/AppsFlyerAdobeAEPExtension.podspec
@@ -6,7 +6,7 @@
 #  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
 #
 version_appsflyerLib = '6.17.8'
-version_plugin = '6.17.9'
+version_plugin = '6.17.81'
    
 Pod::Spec.new do |s|
   s.name             = 'AppsFlyerAdobeAEPExtension'

--- a/AppsFlyerAdobeAEPExtension.podspec
+++ b/AppsFlyerAdobeAEPExtension.podspec
@@ -6,7 +6,7 @@
 #  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
 #
 version_appsflyerLib = '6.17.8'
-version_plugin = '6.17.8'
+version_plugin = '6.17.9'
    
 Pod::Spec.new do |s|
   s.name             = 'AppsFlyerAdobeAEPExtension'

--- a/AppsFlyerAdobeExtension/Sources/AppsFlyerConstants.swift
+++ b/AppsFlyerAdobeExtension/Sources/AppsFlyerConstants.swift
@@ -9,7 +9,7 @@ import Foundation
 enum AppsFlyerConstants {
   static let EXTENSION_NAME = "com.appsflyer.adobeextension" 
   static let FRIENDLY_NAME = "AppsFlyerAdobeExtension"
-  static let EXTENSION_VERSION = "6.17.8"
+  static let EXTENSION_VERSION = "6.17.9"
   static let EVENT_GETTER_RESPONSE_DATA_KEY = "getterdata"
   static let EVENT_SETTER_REQUEST_DATA_KEY = "setterdata"
   static let AF_BRIDGE_SET = "bridge is set"

--- a/AppsFlyerAdobeExtension/Sources/AppsFlyerConstants.swift
+++ b/AppsFlyerAdobeExtension/Sources/AppsFlyerConstants.swift
@@ -9,7 +9,7 @@ import Foundation
 enum AppsFlyerConstants {
   static let EXTENSION_NAME = "com.appsflyer.adobeextension" 
   static let FRIENDLY_NAME = "AppsFlyerAdobeExtension"
-  static let EXTENSION_VERSION = "6.17.9"
+  static let EXTENSION_VERSION = "6.17.81"
   static let EVENT_GETTER_RESPONSE_DATA_KEY = "getterdata"
   static let EVENT_SETTER_REQUEST_DATA_KEY = "setterdata"
   static let AF_BRIDGE_SET = "bridge is set"

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(name: "AppsFlyerLib" , url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Static.git",  .exact("6.17.8")),
-        .package(url: "https://github.com/adobe/aepsdk-core-ios.git", from: "4.0.0"),
-        .package(url: "https://github.com/adobe/aepsdk-edge-ios.git", from: "4.0.0")
+        .package(url: "https://github.com/adobe/aepsdk-core-ios.git", .upToNextMajor(from: "5.0.0")),
+        .package(url: "https://github.com/adobe/aepsdk-edge-ios.git", .upToNextMajor(from: "5.0.0"))
 
     ],
     targets: [

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,4 @@
-### 6.17.9
+### 6.17.81
 * * Fix SPM dependency conflict by widening Adobe AEP SDK range to 5.x (`aepsdk-core-ios` and `aepsdk-edge-ios` now `.upToNextMajor(from: "5.0.0")`)
 
 ### 6.17.8

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,6 @@
+### 6.17.9
+* * Fix SPM dependency conflict by widening Adobe AEP SDK range to 5.x (`aepsdk-core-ios` and `aepsdk-edge-ios` now `.upToNextMajor(from: "5.0.0")`)
+
 ### 6.17.8
 * * Appsflyer SDK dependency to 6.17.8
 


### PR DESCRIPTION
## Summary
  - Fix SPM "Package Resolution Failed" when integrating alongside Adobe AEP 5.x.
  - Widen Adobe AEP pin in Package.swift to `.upToNextMajor(from: "5.0.0")` for both `aepsdk-core-ios` and `aepsdk-edge-ios`.
  - Bump plugin version 6.17.8 → 6.17.81 (AppsFlyer Core SDK dependency stays at 6.17.8).
  - Remove deprecated `AEPMobileServices` import from sample app (ACP-era legacy).

  ## Test plan
  - [x] SPM resolves the extension against Adobe 5.x (`aepsdk-core-ios 5.8.0`, `aepsdk-analytics-ios 5.0.2`).
  - [x] AdobeAEPSample builds + runs under SPM, EventHub registers extension as `6.17.81`.
  - [x] `pod lib lint AppsFlyerAdobeAEPExtension.podspec --allow-warnings` passes.